### PR TITLE
Reading pause time from pool.

### DIFF
--- a/zpool.go
+++ b/zpool.go
@@ -105,6 +105,7 @@ type PoolScanStat struct {
 	// Values not stored on disk
 	PassExam  uint64 // Examined bytes per scan pass
 	PassStart uint64 // Start time of scan pass
+	PassPause uint64 // Pause time
 }
 
 // VDevTree ZFS virtual device tree
@@ -215,6 +216,7 @@ func poolGetConfig(name string, nv C.nvlist_ptr) (vdevs VDevTree, err error) {
 		vdevs.ScanStat.Errors = uint64(ps.pss_errors)
 		vdevs.ScanStat.PassExam = uint64(ps.pss_pass_exam)
 		vdevs.ScanStat.PassStart = uint64(ps.pss_pass_start)
+		vdevs.ScanStat.PassPause = uint64(ps.pss_pass_scrub_pause)
 	}
 
 	// Fetch the children


### PR DESCRIPTION
The pause time is required for deciding whether the scrubbing is paused or not.